### PR TITLE
0.0.1 release

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,13 +2,30 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="161b0c21-8793-4914-8ada-e3ebceb6a3e3" name="Default" comment="">
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pom.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/rmover-json.iml" beforeDir="false" afterPath="$PROJECT_DIR$/rmover-json.iml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/YarmiTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/SimpleServiceAdvertiser.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/SimpleServiceDiscovery.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIError.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIError.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Request.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Request.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/HandshakeFailException.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/HandshakeFailException.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocket.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocket.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java" afterDir="false" />
     </list>
     <ignored path="$PROJECT_DIR$/out/" />
@@ -25,8 +42,8 @@
       <file leaf-file-name="RMIService.java" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIService.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="257">
-              <caret line="43" column="21" selection-start-line="43" selection-start-column="21" selection-end-line="43" selection-end-column="21" />
+            <state relative-caret-position="306">
+              <caret line="97" column="27" selection-start-line="97" selection-start-column="27" selection-end-line="97" selection-end-column="27" />
               <folding>
                 <element signature="imports" expanded="true" />
               </folding>
@@ -34,11 +51,11 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="YarmiTest.java" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/YarmiTest.java">
+      <file leaf-file-name="Main.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="536">
-              <caret line="66" column="21" selection-start-line="66" selection-start-column="21" selection-end-line="66" selection-end-column="21" />
+            <state relative-caret-position="284">
+              <caret line="29" column="19" selection-start-line="29" selection-start-column="19" selection-end-line="29" selection-end-column="19" />
               <folding>
                 <element signature="imports" expanded="true" />
               </folding>
@@ -46,20 +63,11 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="ServiceDiscovery.java" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceDiscovery.java">
+      <file leaf-file-name="RMIBasicTest.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="108">
-              <caret line="9" column="52" selection-start-line="9" selection-start-column="52" selection-end-line="9" selection-end-column="52" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="SimpleServiceAdvertiser.java" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="196">
-              <caret line="25" column="13" selection-start-line="25" selection-start-column="13" selection-end-line="25" selection-end-column="13" />
+            <state relative-caret-position="191">
+              <caret line="23" column="35" selection-start-line="23" selection-start-column="35" selection-end-line="23" selection-end-column="35" />
             </state>
           </provider>
         </entry>
@@ -67,55 +75,71 @@
       <file leaf-file-name="SimpleServiceDiscovery.java" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="180">
-              <caret line="22" column="13" selection-start-line="22" selection-start-column="13" selection-end-line="22" selection-end-column="13" />
+            <state relative-caret-position="18">
+              <caret line="27" column="8" selection-start-line="27" selection-start-column="8" selection-end-line="27" selection-end-column="8" />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="README.md" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/README.md">
-          <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
-            <state split_layout="SPLIT">
-              <first_editor relative-caret-position="18">
-                <caret line="1" column="161" selection-start-line="1" selection-start-column="161" selection-end-line="1" selection-end-column="161" />
-                <folding>
-                  <element signature="e#621#622#0" expanded="true" />
-                </folding>
-              </first_editor>
-              <second_editor />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="pom.xml" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/pom.xml">
+      <file leaf-file-name="ServiceProxyFactory.java" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="306">
-              <caret line="47" column="9" selection-end-line="125" selection-end-column="10" />
+            <state relative-caret-position="414">
+              <caret line="25" column="25" selection-start-line="25" selection-start-column="25" selection-end-line="25" selection-end-column="25" />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="Properties.java" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Properties.java">
+      <file leaf-file-name="InetServiceAdapter.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="180">
-              <caret line="10" column="23" selection-start-line="10" selection-start-column="23" selection-end-line="10" selection-end-column="23" />
+            <state relative-caret-position="270">
+              <caret line="54" selection-start-line="54" selection-end-line="54" />
+              <folding>
+                <element signature="imports" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="project.properties" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/main/resources/project.properties">
-          <provider selected="true" editor-type-id="text-editor" />
+      <file leaf-file-name="SimpleServiceAdvertiser.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="572">
+              <caret line="48" column="20" lean-forward="true" selection-start-line="48" selection-start-column="20" selection-end-line="48" selection-end-column="20" />
+            </state>
+          </provider>
         </entry>
       </file>
-      <file leaf-file-name="RMIClient.java" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java">
+      <file leaf-file-name="BaseServiceDiscovery.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="232">
-              <caret line="58" column="26" selection-start-line="58" selection-start-column="26" selection-end-line="58" selection-end-column="26" />
+            <state relative-caret-position="-317">
+              <caret line="21" column="7" selection-start-line="21" selection-start-column="7" selection-end-line="21" selection-end-column="7" />
+              <folding>
+                <element signature="imports" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="ServiceAdvertiser.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="216">
+              <caret line="14" column="9" selection-start-line="14" selection-start-column="9" selection-end-line="14" selection-end-column="9" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="InetServiceProxy.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="331">
+              <caret line="55" column="33" selection-start-line="55" selection-start-column="33" selection-end-line="55" selection-end-column="33" />
+              <folding>
+                <element signature="imports" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -126,8 +150,8 @@
     <option name="RECENT_TEMPLATES">
       <list>
         <option value="Enum" />
-        <option value="Interface" />
         <option value="Class" />
+        <option value="Interface" />
       </list>
     </option>
   </component>
@@ -143,8 +167,14 @@
       <find>syst</find>
       <find>S</find>
       <find>System</find>
+      <find>log</find>
+      <find>prin</find>
+      <find>pri</find>
+      <find>print</find>
+      <find>//</find>
     </findStrings>
     <dirStrings>
+      <dir>$PROJECT_DIR$/src/main</dir>
       <dir>$PROJECT_DIR$/src/main/java/com/doodream/rmovjs</dir>
     </dirStrings>
   </component>
@@ -154,57 +184,57 @@
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/ServiceInfo.java" />
-        <option value="$PROJECT_DIR$/.gitignore" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/model/RMIServiceRegistry.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/LocalServiceRegistry.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/annotation/parameter/KeyValue.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java" />
         <option value="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/service/TestService.java" />
         <option value="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIServerTest.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java" />
         <option value="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIClientTest.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocket.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapterFactory.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/parameter/Param.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/example/TestService.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/annotation/server/Service.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMIServiceProxy.java" />
-        <option value="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/serde/JsonUtil.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/serde/SerdeUtil.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIService.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIError.java" />
         <option value="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/service/UserIDPController.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/SerdeUtil.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/example/UserIDControllerImpl.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/example/User.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Response.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/example/UserIDPController.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Endpoint.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Request.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceDiscoveryListener.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceDiscovery.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/LocalServiceAdvertiser.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIController.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/LocalServiceDiscovery.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/SimpleServiceAdvertiser.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java" />
         <option value="$PROJECT_DIR$/README.md" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceAdvertiser.java" />
         <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/local/SimpleServiceDiscovery.java" />
-        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIError.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/HandshakeFailException.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java" />
         <option value="$PROJECT_DIR$/pom.xml" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocketFactory.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Request.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocket.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIService.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java" />
+        <option value="$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java" />
+        <option value="$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java" />
       </list>
     </option>
   </component>
@@ -232,9 +262,9 @@
   </component>
   <component name="ProjectFrameBounds" extendedState="6">
     <option name="x" value="1665" />
-    <option name="y" value="-4" />
+    <option name="y" value="24" />
     <option name="width" value="1855" />
-    <option name="height" value="1084" />
+    <option name="height" value="1056" />
   </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">
     <entry key="Project Default">
@@ -257,7 +287,6 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <expand>
@@ -296,6 +325,42 @@
               <item name="rmover-json" type="462c0819:PsiDirectoryNode" />
               <item name="src" type="462c0819:PsiDirectoryNode" />
               <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="java" type="462c0819:PsiDirectoryNode" />
+              <item name="rmovjs" type="462c0819:PsiDirectoryNode" />
+              <item name="model" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="rmover-json" type="b2602c69:ProjectViewProjectNode" />
+              <item name="rmover-json" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="java" type="462c0819:PsiDirectoryNode" />
+              <item name="rmovjs" type="462c0819:PsiDirectoryNode" />
+              <item name="net" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="rmover-json" type="b2602c69:ProjectViewProjectNode" />
+              <item name="rmover-json" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="java" type="462c0819:PsiDirectoryNode" />
+              <item name="rmovjs" type="462c0819:PsiDirectoryNode" />
+              <item name="sdp" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="rmover-json" type="b2602c69:ProjectViewProjectNode" />
+              <item name="rmover-json" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="java" type="462c0819:PsiDirectoryNode" />
+              <item name="rmovjs" type="462c0819:PsiDirectoryNode" />
+              <item name="server" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="rmover-json" type="b2602c69:ProjectViewProjectNode" />
+              <item name="rmover-json" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
               <item name="resources" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
@@ -307,6 +372,7 @@
           <select />
         </subPane>
       </pane>
+      <pane id="Scope" />
       <pane id="AndroidView" />
       <pane id="PackagesPane" />
     </panes>
@@ -408,6 +474,7 @@
               <list>
                 <option value="clean" />
                 <option value="install" />
+                <option value="-U" />
               </list>
             </option>
             <option name="pomFileName" />
@@ -472,12 +539,13 @@
       <workItem from="1526564541696" duration="9529000" />
       <workItem from="1526772538738" duration="1592000" />
       <workItem from="1526817481326" duration="19772000" />
-      <workItem from="1526883780705" duration="20042000" />
+      <workItem from="1526883780705" duration="20329000" />
+      <workItem from="1526909828037" duration="23217000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="153067000" />
+    <option name="totallyTimeSpent" value="176571000" />
   </component>
   <component name="TodoView">
     <todo-panel id="selected-file">
@@ -489,7 +557,7 @@
     </todo-panel>
   </component>
   <component name="ToolWindowManager">
-    <frame x="1664" y="-11" width="1857" height="1092" extended-state="6" />
+    <frame x="1665" y="-4" width="1855" height="1084" extended-state="6" />
     <editor active="true" />
     <layout>
       <window_info anchor="right" id="PlantUML" order="3" weight="0.38529575" />
@@ -511,9 +579,9 @@
       <window_info id="Image Layers" order="7" />
       <window_info anchor="right" id="Capture Analysis" order="7" />
       <window_info anchor="bottom" id="Version Control" order="10" weight="0.33978495" />
-      <window_info anchor="bottom" id="Run" order="2" sideWeight="0.49806523" weight="0.45588234" />
-      <window_info active="true" anchor="bottom" id="Terminal" order="9" sideWeight="0.49585405" visible="true" weight="0.32563025" />
-      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.3370227" />
+      <window_info anchor="bottom" id="Run" order="2" sideWeight="0.49806523" weight="0.36869746" />
+      <window_info anchor="bottom" id="Terminal" order="9" sideWeight="0.49585405" visible="true" weight="0.4012605" />
+      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.28943" />
       <window_info anchor="bottom" id="Find" order="1" weight="0.32563025" />
       <window_info anchor="right" id="SciView" order="9" />
       <window_info anchor="right" id="Theme Preview" order="9" />
@@ -534,113 +602,6 @@
     <option name="myLimit" value="2678400000" />
   </component>
   <component name="editorHistoryManager">
-    <entry file="jar:///usr/lib/jvm/java-8-oracle/src.zip!/java/net/Socket.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="954">
-          <caret line="82" column="11" selection-start-line="82" selection-start-column="11" selection-end-line="82" selection-end-column="11" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIServerTest.java" />
-    <entry file="jar:///usr/lib/jvm/java-8-oracle/src.zip!/java/io/PrintWriter.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="163">
-          <caret line="55" column="13" selection-start-line="55" selection-start-column="13" selection-end-line="55" selection-end-column="13" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="jar:///usr/lib/jvm/java-8-oracle/src.zip!/java/io/BufferedReader.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="325">
-          <caret line="387" column="18" selection-start-line="387" selection-start-column="18" selection-end-line="387" selection-end-column="18" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="216">
-          <caret line="17" column="9" selection-start-line="17" selection-start-column="9" selection-end-line="17" selection-end-column="9" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="jar://$MAVEN_REPOSITORY$/io/reactivex/rxjava2/rxjava/2.1.0/rxjava-2.1.0.jar!/io/reactivex/Observable.class">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="205">
-          <caret line="2786" column="28" selection-start-line="2786" selection-start-column="28" selection-end-line="2786" selection-end-column="28" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapterFactory.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="108">
-          <caret line="9" column="23" selection-start-line="9" selection-start-column="23" selection-end-line="9" selection-end-column="23" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="342">
-          <caret line="23" column="5" selection-start-line="23" selection-start-column="5" selection-end-line="23" selection-end-column="5" />
-          <folding>
-            <element signature="imports" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/service/BasicSerivceTest.java" />
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/annotation/server/Service.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-36">
-          <caret line="16" column="21" selection-start-line="16" selection-start-column="21" selection-end-line="16" selection-end-column="21" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="322">
-          <caret line="47" column="5" lean-forward="true" selection-start-line="47" selection-start-column="5" selection-end-line="47" selection-end-column="5" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocket.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="126">
-          <caret line="9" column="9" selection-start-line="9" selection-start-column="9" selection-end-line="9" selection-end-column="9" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="198">
-          <caret line="16" column="20" lean-forward="true" selection-start-line="16" selection-start-column="20" selection-end-line="16" selection-end-column="20" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMIServiceProxy.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-126">
-          <caret line="11" column="20" selection-start-line="11" selection-start-column="20" selection-end-line="11" selection-end-column="20" />
-          <folding>
-            <element signature="e#835#836#0" expanded="true" />
-            <element signature="e#871#872#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/ControllerInfo.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="144">
-          <caret line="12" column="13" selection-start-line="12" selection-start-column="13" selection-end-line="12" selection-end-column="13" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/ErrorMessage.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="144">
-          <caret line="11" column="13" selection-start-line="11" selection-start-column="13" selection-end-line="11" selection-end-column="13" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/service/TestService.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="72">
@@ -652,68 +613,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="72">
           <caret line="6" column="5" selection-start-line="6" selection-start-column="5" selection-end-line="6" selection-end-column="5" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIError.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="268">
-          <caret line="17" column="53" selection-start-line="17" selection-start-column="53" selection-end-line="17" selection-end-column="53" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="393">
-          <caret line="51" column="38" selection-start-line="51" selection-start-column="38" selection-end-line="51" selection-end-column="38" />
-          <folding>
-            <element signature="imports" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="198">
-          <caret line="19" column="33" selection-start-line="19" selection-start-column="33" selection-end-line="19" selection-end-column="33" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="306">
-          <caret line="36" column="8" selection-start-line="36" selection-start-column="8" selection-end-line="36" selection-end-column="8" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="189">
-          <caret line="68" column="41" selection-start-line="68" selection-start-column="41" selection-end-line="68" selection-end-column="41" />
-          <folding>
-            <element signature="imports" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="281">
-          <caret line="61" column="38" selection-start-line="61" selection-start-column="38" selection-end-line="61" selection-end-column="38" />
-          <folding>
-            <element signature="imports" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/parameter/Param.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="268">
-          <caret line="50" column="47" selection-start-line="50" selection-start-column="47" selection-end-line="50" selection-end-column="47" />
-          <folding>
-            <element signature="e#1330#1331#0" expanded="true" />
-            <element signature="e#1395#1396#0" expanded="true" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -778,41 +677,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceDiscoveryListener.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="90">
-          <caret line="7" column="44" selection-start-line="7" selection-start-column="44" selection-end-line="7" selection-end-column="44" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="252">
-          <caret line="16" column="23" selection-start-line="16" selection-start-column="23" selection-end-line="16" selection-end-column="23" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Response.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-360">
-          <caret line="23" column="13" selection-start-line="23" selection-start-column="13" selection-end-line="23" selection-end-column="13" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/method/RMIMethod.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="257">
           <caret line="73" column="26" selection-start-line="73" selection-start-column="26" selection-end-line="73" selection-end-column="26" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIController.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="299">
-          <caret line="42" column="42" lean-forward="true" selection-start-line="42" selection-start-column="42" selection-end-line="42" selection-end-column="42" />
-          <folding>
-            <element signature="imports" expanded="true" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -823,63 +691,78 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Request.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="722">
-          <caret line="69" selection-start-line="69" selection-end-line="69" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="414">
-          <caret line="43" selection-start-line="43" selection-end-line="43" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="232">
-          <caret line="58" column="26" selection-start-line="58" selection-start-column="26" selection-end-line="58" selection-end-column="26" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/README.md">
       <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
         <state split_layout="SPLIT">
           <first_editor relative-caret-position="18">
             <caret line="1" column="161" selection-start-line="1" selection-start-column="161" selection-end-line="1" selection-end-column="161" />
-            <folding>
-              <element signature="e#621#622#0" expanded="true" />
-            </folding>
           </first_editor>
           <second_editor />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceAdvertiser.java">
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceAdvertiser.java" />
+    <entry file="file://$PROJECT_DIR$/src/main/resources/project.properties">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Properties.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="288">
-          <caret line="16" lean-forward="true" selection-start-line="16" selection-end-line="16" />
+        <state relative-caret-position="180">
+          <caret line="10" column="23" selection-start-line="10" selection-start-column="23" selection-end-line="10" selection-end-column="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceDiscoveryListener.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="90">
+          <caret line="7" column="44" selection-start-line="7" selection-start-column="44" selection-end-line="7" selection-end-column="44" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/parameter/Param.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="268">
+          <caret line="50" column="47" selection-start-line="50" selection-start-column="47" selection-end-line="50" selection-end-column="47" />
           <folding>
-            <element signature="imports" expanded="true" />
-            <element signature="e#259#260#0" expanded="true" />
-            <element signature="e#297#298#0" expanded="true" />
+            <element signature="e#1330#1331#0" expanded="true" />
+            <element signature="e#1395#1396#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java">
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIError.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="196">
-          <caret line="25" column="13" selection-start-line="25" selection-start-column="13" selection-end-line="25" selection-end-column="13" />
+        <state relative-caret-position="126">
+          <caret line="8" lean-forward="true" selection-start-line="8" selection-end-line="8" />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java">
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Response.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="180">
-          <caret line="22" column="13" selection-start-line="22" selection-start-column="13" selection-end-line="22" selection-end-column="13" />
+        <state relative-caret-position="18">
+          <caret line="44" column="27" selection-start-line="44" selection-start-column="27" selection-end-line="44" selection-end-column="27" />
+          <folding>
+            <element signature="e#1124#1125#0" expanded="true" />
+            <element signature="e#1187#1188#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/HandshakeFailException.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="126">
+          <caret line="7" column="26" lean-forward="true" selection-start-line="7" selection-start-column="26" selection-end-line="7" selection-end-column="26" />
+          <folding>
+            <element signature="e#275#276#0" expanded="true" />
+            <element signature="e#316#317#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/annotation/server/Controller.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="9" column="10" selection-start-line="9" selection-start-column="10" selection-end-line="9" selection-end-column="10" />
         </state>
       </provider>
     </entry>
@@ -890,13 +773,176 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/resources/project.properties">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/YarmiTest.java">
+    <entry file="file://$PROJECT_DIR$/pom.xml">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="536">
-          <caret line="66" column="21" selection-start-line="66" selection-start-column="21" selection-end-line="66" selection-end-column="21" />
+        <state relative-caret-position="477">
+          <caret line="116" column="21" selection-start-line="116" selection-start-column="21" selection-end-line="116" selection-end-column="21" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapterFactory.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="108">
+          <caret line="9" column="23" selection-start-line="9" selection-start-column="23" selection-end-line="9" selection-end-column="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocketFactory.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="54">
+          <caret line="3" column="51" lean-forward="true" selection-start-line="3" selection-start-column="51" selection-end-line="3" selection-end-column="51" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="jar:///usr/lib/jvm/java-8-oracle/src.zip!/java/net/DatagramPacket.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="461">
+          <caret line="189" column="36" selection-start-line="189" selection-start-column="36" selection-end-line="189" selection-end-column="36" />
+          <folding>
+            <element signature="e#5705#5706#0" expanded="true" />
+            <element signature="e#5735#5736#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="jar:///usr/lib/jvm/java-8-oracle/src.zip!/java/net/InetSocketAddress.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="245">
+          <caret line="51" column="13" selection-start-line="51" selection-start-column="13" selection-end-line="51" selection-end-column="13" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMIServiceProxy.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-63">
+          <caret line="10" column="17" selection-start-line="10" selection-start-column="17" selection-end-line="10" selection-end-column="17" />
+          <folding>
+            <element signature="e#835#836#0" expanded="true" />
+            <element signature="e#871#872#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServerSocketAdapterFactory.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="72">
+          <caret line="5" column="17" selection-start-line="5" selection-start-column="17" selection-end-line="5" selection-end-column="17" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/ControllerInfo.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="180">
+          <caret line="14" column="21" selection-start-line="14" selection-start-column="21" selection-end-line="14" selection-end-column="21" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIController.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="135">
+          <caret line="30" column="24" selection-start-line="30" selection-start-column="24" selection-end-line="30" selection-end-column="24" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="360">
+          <caret line="25" column="24" selection-start-line="25" selection-start-column="24" selection-end-line="25" selection-end-column="24" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/client/RMIClient.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="223">
+          <caret line="84" column="7" selection-start-line="84" selection-start-column="7" selection-end-line="84" selection-end-column="7" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="513">
+          <caret line="94" column="38" selection-start-line="94" selection-start-column="38" selection-end-line="94" selection-end-column="38" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/model/Request.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="88">
+          <caret line="28" column="35" selection-start-line="28" selection-start-column="35" selection-end-line="28" selection-end-column="35" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="13" column="34" selection-start-line="13" selection-start-column="34" selection-end-line="13" selection-end-column="34" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/RMISocket.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="198">
+          <caret line="13" column="27" selection-start-line="13" selection-start-column="27" selection-end-line="13" selection-end-column="27" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="410">
+          <caret line="87" column="31" selection-start-line="87" selection-start-column="31" selection-end-line="87" selection-end-column="31" />
+          <folding>
+            <element signature="imports" expanded="true" />
+            <element signature="e#3169#3170#0" expanded="true" />
+            <element signature="e#3199#3200#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="14" column="37" selection-start-line="14" selection-start-column="37" selection-end-line="14" selection-end-column="37" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="459">
+          <caret line="68" column="65" selection-start-line="68" selection-start-column="65" selection-end-line="68" selection-end-column="65" />
+          <folding>
+            <element signature="e#1791#1792#0" expanded="true" />
+            <element signature="e#1846#1847#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="198">
+          <caret line="11" column="7" selection-start-line="11" selection-start-column="7" selection-end-line="11" selection-end-column="7" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxy.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="331">
+          <caret line="55" column="33" selection-start-line="55" selection-start-column="33" selection-end-line="55" selection-end-column="33" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/inet/InetServiceAdapter.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="270">
+          <caret line="54" selection-start-line="54" selection-end-line="54" />
           <folding>
             <element signature="imports" expanded="true" />
           </folding>
@@ -905,25 +951,66 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/server/RMIService.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="257">
-          <caret line="43" column="21" selection-start-line="43" selection-start-column="21" selection-end-line="43" selection-end-column="21" />
+        <state relative-caret-position="306">
+          <caret line="97" column="27" selection-start-line="97" selection-start-column="27" selection-end-line="97" selection-end-column="27" />
           <folding>
             <element signature="imports" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Properties.java">
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/Main.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="180">
-          <caret line="10" column="23" selection-start-line="10" selection-start-column="23" selection-end-line="10" selection-end-column="23" />
+        <state relative-caret-position="284">
+          <caret line="29" column="19" selection-start-line="29" selection-start-column="19" selection-end-line="29" selection-end-column="19" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/pom.xml">
+    <entry file="file://$PROJECT_DIR$/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="306">
-          <caret line="47" column="9" selection-end-line="125" selection-end-column="10" />
+        <state relative-caret-position="191">
+          <caret line="23" column="35" selection-start-line="23" selection-start-column="35" selection-end-line="23" selection-end-column="35" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="216">
+          <caret line="14" column="9" selection-start-line="14" selection-start-column="9" selection-end-line="14" selection-end-column="9" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-317">
+          <caret line="21" column="7" selection-start-line="21" selection-start-column="7" selection-end-line="21" selection-end-column="7" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="572">
+          <caret line="48" column="20" lean-forward="true" selection-start-line="48" selection-start-column="20" selection-end-line="48" selection-end-column="20" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="18">
+          <caret line="27" column="8" selection-start-line="27" selection-start-column="8" selection-end-line="27" selection-end-column="8" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="414">
+          <caret line="25" column="25" selection-start-line="25" selection-start-column="25" selection-end-line="25" selection-end-column="25" />
         </state>
       </provider>
     </entry>

--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,13 @@
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>
                             </descriptorRefs>
-                            <archive>
-                                <manifest>
-                                    <mainClass>
-                                        com.doodream.rmovjs.Main
-                                    </mainClass>
-                                </manifest>
-                            </archive>
+                            <!--<archive>-->
+                                <!--<manifest>-->
+                                    <!--<mainClass>-->
+                                        <!--com.doodream.rmovjs.Main-->
+                                    <!--</mainClass>-->
+                                <!--</manifest>-->
+                            <!--</archive>-->
                         </configuration>
                     </execution>
                 </executions>
@@ -105,7 +105,16 @@
             <artifactId>jmdns</artifactId>
             <version>1.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.11.0</version>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/rmover-json.iml
+++ b/rmover-json.iml
@@ -20,6 +20,8 @@
     <orderEntry type="library" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
     <orderEntry type="library" name="Maven: org.projectlombok:lombok:1.16.18" level="project" />
     <orderEntry type="library" name="Maven: jmdns:jmdns:1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.11.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.11.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.2" level="project" />
     <orderEntry type="library" name="Maven: io.reactivex.rxjava2:rxjava:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.reactivestreams:reactive-streams:1.0.0" level="project" />

--- a/src/main/java/com/doodream/rmovjs/Main.java
+++ b/src/main/java/com/doodream/rmovjs/Main.java
@@ -23,7 +23,7 @@ public class Main {
         new Thread(() -> {
             try {
                 RMIService service = RMIService.create(TestService.class, new SimpleServiceAdvertiser());
-                service.listen();
+                service.listen(true);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/doodream/rmovjs/model/RMIError.java
+++ b/src/main/java/com/doodream/rmovjs/model/RMIError.java
@@ -19,4 +19,5 @@ public enum RMIError {
         nresponse.setEndpoint(request.getEndpoint());
         return nresponse;
     }
+
 }

--- a/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java
+++ b/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java
@@ -14,6 +14,7 @@ import com.google.gson.stream.JsonWriter;
 import io.reactivex.Observable;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -23,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @Builder
+@EqualsAndHashCode(exclude = {"proxyFactoryHint"})
 @Data
 public class RMIServiceInfo {
 
@@ -40,6 +42,13 @@ public class RMIServiceInfo {
 
     @SerializedName("interfaces")
     private List<ControllerInfo> controllerInfos;
+
+    /**
+     *  remoteHint is used to guess conntion information (like address or bluetooth device name etc.,)
+     *
+     */
+    @SerializedName("hint")
+    private String proxyFactoryHint;
 
 
     public static <T> RMIServiceInfo from(Class<T> svc) {
@@ -60,7 +69,11 @@ public class RMIServiceInfo {
                 .subscribe();
 
         return builder.build();
+    }
 
+    public static boolean isComplete(RMIServiceInfo info) {
+        return (info.getProxyFactoryHint() != null) &&
+                (info.getControllerInfos() != null);
     }
 
     public String toJson() {
@@ -71,5 +84,14 @@ public class RMIServiceInfo {
         JsonReader reader = new JsonReader(new StringReader(new String(bytes, "UTF-8")));
         reader.setLenient(true);
         return SerdeUtil.fromJson(reader, RMIServiceInfo.class);
+    }
+
+    public void copyFrom(RMIServiceInfo info) {
+        setProxyFactoryHint(info.getProxyFactoryHint());
+        setParams(info.getParams());
+        setAdapter(info.getAdapter());
+        setControllerInfos(info.getControllerInfos());
+        setName(info.getName());
+        setVersion(info.getVersion());
     }
 }

--- a/src/main/java/com/doodream/rmovjs/model/Request.java
+++ b/src/main/java/com/doodream/rmovjs/model/Request.java
@@ -27,8 +27,7 @@ import java.util.List;
 public class Request {
 
     private transient ClientSocketAdapter client;
-    @SerializedName("service")
-    private RMIServiceInfo serviceInfo;
+    @SerializedName("endpoint")
     private Endpoint endpoint;
 
     public void response(Response s) throws IOException {

--- a/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java
+++ b/src/main/java/com/doodream/rmovjs/net/ClientSocketAdapter.java
@@ -10,9 +10,13 @@ import java.io.IOException;
 
 public interface ClientSocketAdapter {
 
+    /**
+     * write response to transport
+     * @param response
+     * @throws IOException
+     */
     void write(Response response) throws IOException;
     Observable<Request> listen() throws IOException;
     boolean handshake(RMIServiceInfo serviceInfo) throws IOException;
     String who();
-    String unique();
 }

--- a/src/main/java/com/doodream/rmovjs/net/HandshakeFailException.java
+++ b/src/main/java/com/doodream/rmovjs/net/HandshakeFailException.java
@@ -4,4 +4,8 @@ public class HandshakeFailException extends RuntimeException {
     public HandshakeFailException(ClientSocketAdapter adapter) {
         super(String.format("Handshake failed : %s", adapter.who()));
     }
+
+    public HandshakeFailException() {
+        super("Handshake failed");
+    }
 }

--- a/src/main/java/com/doodream/rmovjs/net/RMISocket.java
+++ b/src/main/java/com/doodream/rmovjs/net/RMISocket.java
@@ -8,5 +8,8 @@ public interface RMISocket {
     InputStream getInputStream() throws IOException;
     OutputStream getOutputStream() throws IOException;
     void close() throws IOException;
+    void open() throws IOException;
     boolean isConnected();
+    boolean isClosed();
+    String getRemoteName();
 }

--- a/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java
+++ b/src/main/java/com/doodream/rmovjs/net/ServiceAdapter.java
@@ -15,7 +15,14 @@ import java.io.IOException;
  *
  */
 public interface ServiceAdapter {
-    void listen(RMIServiceInfo serviceInfo, Function<Request, Response> requestHandler) throws IOException;
+    /**
+     *
+     * @param serviceInfo
+     * @param requestHandler
+     * @return proxyFactoryHint as string
+     * @throws IOException
+     */
+    String listen(RMIServiceInfo serviceInfo, Function<Request, Response> requestHandler) throws IOException;
     ServiceProxyFactory getProxyFactory(RMIServiceInfo info);
     void close() throws IOException;
 }

--- a/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java
+++ b/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java
@@ -16,5 +16,12 @@ import java.io.IOException;
  *  이를 통해서 ServiceProxyFactory는 현재 서버측의 네트워킹을 위한 파라미터들을 유추 혹은 추출 할 수 있다.
  */
 public interface ServiceProxyFactory {
-    RMIServiceProxy build(RMIServiceInfo info) throws IOException;
+    /**
+     * build RMIServiceProxy to remote service adapter would be comprised of below
+     * 1. create RMISocket on which RMIServiceProxy depend
+     * @return
+     * @throws IOException
+     */
+    RMIServiceProxy build() throws IOException;
+    void setTargetService(RMIServiceInfo info);
 }

--- a/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java
+++ b/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapter.java
@@ -8,18 +8,12 @@ import com.doodream.rmovjs.model.Response;
 import com.doodream.rmovjs.net.ClientSocketAdapter;
 import com.doodream.rmovjs.net.RMISocket;
 import com.doodream.rmovjs.net.SerdeUtil;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Locale;
 
 public class InetClientSocketAdapter implements ClientSocketAdapter {
 
@@ -49,7 +43,7 @@ public class InetClientSocketAdapter implements ClientSocketAdapter {
 
             Observable<Response> serviceInfoMismatchObservable = handshakeRequestSingle
                     .filter(info -> info.hashCode() != serviceInfo.hashCode())
-                    .map(info -> RMIError.FORBIDDEN.getResponse(Request.builder().serviceInfo(serviceInfo).build()));
+                    .map(info -> RMIError.FORBIDDEN.getResponse(Request.builder().build()));
 
             return serviceInfoMatchedObservable.mergeWith(serviceInfoMismatchObservable)
                     .doOnNext(this::write)
@@ -91,12 +85,7 @@ public class InetClientSocketAdapter implements ClientSocketAdapter {
 
     @Override
     public String who() {
-        return serviceInfo.getName();
-    }
-
-    @Override
-    public String unique() {
-        return String.format(Locale.getDefault(), "%d_%d", serviceInfo.hashCode(), client.hashCode());
+        return client.getRemoteName();
     }
 
 }

--- a/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java
+++ b/src/main/java/com/doodream/rmovjs/net/inet/InetClientSocketAdapterFactory.java
@@ -6,8 +6,6 @@ import com.doodream.rmovjs.net.ClientSocketAdapter;
 import com.doodream.rmovjs.net.ClientSocketAdapterFactory;
 import com.doodream.rmovjs.net.HandshakeFailException;
 import com.doodream.rmovjs.net.RMISocket;
-import io.reactivex.Observable;
-import org.omg.PortableInterceptor.SYSTEM_EXCEPTION;
 
 import java.io.IOException;
 

--- a/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java
+++ b/src/main/java/com/doodream/rmovjs/net/inet/InetRMISocket.java
@@ -6,26 +6,37 @@ import com.doodream.rmovjs.net.RMISocket;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketAddress;
 
 public class InetRMISocket implements RMISocket {
 
     private Socket socket;
+    private SocketAddress remoteAddress;
     public InetRMISocket(Socket client) {
         socket = client;
+        remoteAddress = socket.getRemoteSocketAddress();
     }
 
-    public InetRMISocket(String host, int port) throws IOException {
-        socket = new Socket(host, port);
+    public InetRMISocket(String host, int port) {
+        remoteAddress = InetSocketAddress.createUnresolved(host, port);
+        socket = null;
     }
 
     @Override
     public InputStream getInputStream() throws IOException {
+        if(socket == null || socket.isClosed()) {
+            throw new IllegalStateException("Connection is not opened");
+        }
         return socket.getInputStream();
     }
 
     @Override
     public OutputStream getOutputStream() throws IOException {
+        if(socket == null || socket.isClosed()) {
+            throw new IllegalStateException("Connection is not opened");
+        }
         return socket.getOutputStream();
     }
 
@@ -38,8 +49,24 @@ public class InetRMISocket implements RMISocket {
     }
 
     @Override
+    public void open() throws IOException {
+        InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
+        socket = new Socket(inetSocketAddress.getHostName(), inetSocketAddress.getPort());
+    }
+
+    @Override
     public boolean isConnected() {
         return socket.isConnected();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return socket.isClosed();
+    }
+
+    @Override
+    public String getRemoteName() {
+        return ((InetSocketAddress) remoteAddress).getHostName();
     }
 
 

--- a/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java
+++ b/src/main/java/com/doodream/rmovjs/net/inet/InetServiceProxyFactory.java
@@ -7,6 +7,7 @@ import com.doodream.rmovjs.net.ServiceProxyFactory;
 import java.io.IOException;
 
 public class InetServiceProxyFactory implements ServiceProxyFactory {
+    private RMIServiceInfo serviceInfo;
     private int port;
     private String host;
 
@@ -16,7 +17,7 @@ public class InetServiceProxyFactory implements ServiceProxyFactory {
     }
 
     public InetServiceProxyFactory(String port) {
-        this(InetServiceAdapter.DEFAULT_NAME, port);
+        this(null, port);
     }
 
     public InetServiceProxyFactory() {
@@ -24,7 +25,15 @@ public class InetServiceProxyFactory implements ServiceProxyFactory {
     }
 
     @Override
-    public RMIServiceProxy build(RMIServiceInfo info) throws IOException {
-        return InetServiceProxy.create(info, new InetRMISocket(host, port));
+    public RMIServiceProxy build() throws IOException {
+        if(host == null) {
+            host = serviceInfo.getProxyFactoryHint();
+        }
+        return InetServiceProxy.create(serviceInfo, new InetRMISocket(host, port));
+    }
+
+    @Override
+    public void setTargetService(RMIServiceInfo info) {
+        serviceInfo = info;
     }
 }

--- a/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java
@@ -1,0 +1,94 @@
+package com.doodream.rmovjs.sdp;
+
+import com.doodream.rmovjs.model.RMIServiceInfo;
+import com.doodream.rmovjs.net.RMIServiceProxy;
+import com.doodream.rmovjs.net.ServiceAdapter;
+import com.doodream.rmovjs.net.ServiceProxyFactory;
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+public abstract class BaseServiceDiscovery implements ServiceDiscovery {
+
+    private static final Logger LOGGER = LogManager.getLogger(BaseServiceDiscovery.class);
+
+    private static final long TIMEOUT_IN_SEC = 5L;
+    private long tickIntervalinMillisec;
+    private HashMap<RMIServiceInfo, Disposable> disposableMap;
+
+    public BaseServiceDiscovery(long interval, TimeUnit unit) {
+        tickIntervalinMillisec = unit.toMillis(interval);
+        disposableMap = new HashMap<>();
+    }
+
+    @Override
+    public void startDiscovery(RMIServiceInfo info, ServiceDiscoveryListener listener) {
+        startDiscovery(info, listener, TIMEOUT_IN_SEC, TimeUnit.SECONDS);
+    }
+
+
+    private Observable<Long> observeTick() {
+        return Observable.interval(0L, tickIntervalinMillisec, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void startDiscovery(RMIServiceInfo info, ServiceDiscoveryListener listener, long timeout, TimeUnit unit) {
+        HashSet<RMIServiceInfo> discoveryCache = new HashSet<>();
+
+        Observable<RMIServiceInfo> serviceInfoObservable = observeTick()
+                .map(seq -> recvServiceInfo())
+                .onErrorReturn(throwable -> RMIServiceInfo.builder().build())
+                .filter(discoveryCache::add)
+                .filter(info::equals)
+                .doOnNext(info::copyFrom)
+                .timeout(timeout, unit);
+
+
+        disposableMap.put(info, serviceInfoObservable
+                .map(RMIServiceInfo::getAdapter)
+                .map(Class::newInstance)
+                .cast(ServiceAdapter.class)
+                .map(serviceAdapter -> serviceAdapter.getProxyFactory(info))
+                .map(ServiceProxyFactory::build)
+                .doOnDispose(() -> {
+                    listener.onDiscoveryFinished();
+                    close();
+                })
+                .doOnError(throwable -> {
+                    listener.onDiscoveryFinished();
+                    close();
+                })
+                .doOnComplete(() -> {
+                    listener.onDiscoveryFinished();
+                    close();
+                })
+                .onErrorReturn(throwable -> RMIServiceProxy.NULL_PROXY)
+                .filter(proxy -> !RMIServiceProxy.NULL_PROXY.equals(proxy))
+                .subscribe(listener::onDiscovered));
+
+    }
+
+
+    @Override
+    public void cancelDiscovery(RMIServiceInfo info) {
+        Disposable disposable = disposableMap.get(info);
+        if(disposable == null) {
+            return;
+        }
+        if(disposable.isDisposed()) {
+            return;
+        }
+        disposable.dispose();
+    }
+
+
+    protected abstract RMIServiceInfo recvServiceInfo() throws IOException;
+    protected abstract void close();
+}

--- a/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/ServiceAdvertiser.java
@@ -9,9 +9,10 @@ public interface ServiceAdvertiser {
      * start service advertising
      * should not block
      * @param info
+     * @param block
      * @throws IOException
      */
-    void startAdvertiser(RMIServiceInfo info) throws IOException;
+    void startAdvertiser(RMIServiceInfo info, boolean block) throws IOException;
 
     /**
      * stop advertising

--- a/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java
@@ -1,14 +1,13 @@
 package com.doodream.rmovjs.sdp;
 
 import com.doodream.rmovjs.model.RMIServiceInfo;
+import com.doodream.rmovjs.net.RMIServiceProxy;
 import com.doodream.rmovjs.net.ServiceAdapter;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.InetSocketAddress;
+import java.net.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,97 +19,32 @@ import java.util.concurrent.TimeUnit;
  *  listen broadcast message and try to convert the message into RMIServiceInfo.
  *  if there is service broadcast matched to the target service info, then invoke onDiscovered callback of listener
  */
-public class SimpleServiceDiscovery implements ServiceDiscovery {
-    private HashMap<RMIServiceInfo, Disposable> disposableHashMap = new HashMap<>();
-    private HashSet<Integer> discovered = new HashSet<>();
-    private static final byte[] EMPTY_DATA = new byte[0];
+public class SimpleServiceDiscovery extends BaseServiceDiscovery {
 
+    private DatagramSocket serviceBroadcastSocket;
 
-    private DatagramPacket receivePacket(DatagramSocket datagramSocket) throws IOException {
+    public SimpleServiceDiscovery() throws SocketException {
+        super(100L, TimeUnit.MILLISECONDS);
+        serviceBroadcastSocket = new DatagramSocket(new InetSocketAddress(SimpleServiceAdvertiser.BROADCAST_PORT));
+    }
+
+    @Override
+    protected RMIServiceInfo recvServiceInfo() throws IOException {
         byte[] buffer = new byte[64 * 1024];
         Arrays.fill(buffer, (byte) 0);
-        DatagramPacket packet = new DatagramPacket(buffer,buffer.length);
-        try {
-            datagramSocket.receive(packet);
-        } catch (Exception e ) {
-            packet.setData(EMPTY_DATA);
-            return packet;
-        }
-        return packet;
-    }
-
-
-    private Observable<Long> discoveryTickEventObservable() {
-        return Observable.interval(0L, 100L, TimeUnit.MILLISECONDS);
+        DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+        serviceBroadcastSocket.receive(packet);
+        return RMIServiceInfo.from(packet.getData());
     }
 
     @Override
-    public void startDiscovery(RMIServiceInfo info, ServiceDiscoveryListener listener, long timeout, TimeUnit unit) throws IOException {
-        DatagramSocket socket = new DatagramSocket(new InetSocketAddress(SimpleServiceAdvertiser.BROADCAST_PORT));
-        discovered.clear();
-        Observable<Long> tickObservable = discoveryTickEventObservable();
-        Observable<RMIServiceInfo> serviceInfoObservable = tickObservable
-                .map(aLong -> receivePacket(socket))
-                .map(DatagramPacket::getData)
-                .filter(bytes -> bytes.length > 0)
-                .map(RMIServiceInfo::from)
-                .filter(service -> discovered.add(service.hashCode()))
-                .filter(info::equals)
-                .timeout(timeout, unit);
-
-        disposableHashMap.put(info,serviceInfoObservable
-                .map(RMIServiceInfo::getAdapter)
-                .map(Class::newInstance)
-                .cast(ServiceAdapter.class)
-                .map(adapter->adapter.getProxyFactory(info))
-                .doOnDispose(socket::close)
-                .map(serviceProxyFactory -> serviceProxyFactory.build(info))
-                .doOnDispose(() -> {
-                    listener.onDiscoveryFinished();
-                    onStopDiscovery(info, socket);
-                })
-                .doOnError(throwable -> {
-                    listener.onDiscoveryFinished();
-                    onStopDiscovery(info, socket);
-                })
-                .doOnComplete(() -> {
-                    listener.onDiscoveryFinished();
-                    onStopDiscovery(info, socket);
-                })
-                .subscribe(listener::onDiscovered));
-
-        listener.onDiscoveryStarted();
-
-    }
-
-    private void onStopDiscovery(RMIServiceInfo info, DatagramSocket socket) {
-        Disposable disposable = disposableHashMap.get(info);
-        if(disposable != null &&
-                !disposable.isDisposed()) {
-            disposable.dispose();
-        }
-        if(socket.isClosed()) {
+    protected void close() {
+        if(serviceBroadcastSocket == null) {
             return;
         }
-        socket.close();
-    }
-
-
-    @Override
-    public void startDiscovery(RMIServiceInfo info, ServiceDiscoveryListener listener) throws IOException {
-        startDiscovery(info, listener, 5L, TimeUnit.SECONDS);
-    }
-
-    @Override
-    public void cancelDiscovery(RMIServiceInfo info) {
-        Disposable disposable = disposableHashMap.get(info);
-        if(disposable == null) {
+        if(serviceBroadcastSocket.isClosed()) {
             return;
         }
-        if(disposable.isDisposed()) {
-            return;
-        }
-        disposable.dispose();
+        serviceBroadcastSocket.close();
     }
-
 }

--- a/src/main/java/com/doodream/rmovjs/server/RMIService.java
+++ b/src/main/java/com/doodream/rmovjs/server/RMIService.java
@@ -93,9 +93,9 @@ public class RMIService {
     }
 
 
-    public void listen() throws Exception {
-        advertiser.startAdvertiser(serviceInfo);
-        adapter.listen(serviceInfo, this::routeRequest);
+    public void listen(boolean block) throws Exception {
+        serviceInfo.setProxyFactoryHint(adapter.listen(serviceInfo, this::routeRequest));
+        advertiser.startAdvertiser(serviceInfo, block);
     }
 
     private Response routeRequest(Request request) throws InvocationTargetException, IllegalAccessException {

--- a/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java
+++ b/src/test/java/com/doodream/rmovjs/test/RMIBasicTest.java
@@ -21,7 +21,7 @@ public class RMIBasicTest {
         service = RMIService.create(TestService.class, advertiser);
         server = new Thread(() -> {
             try {
-                service.listen();
+                service.listen(true);
             } catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
- add log4j2 as dependency
- RMIService API change
 	- listen has block option as boolean argument
- Connection of RMISocket on client side is deferred to the time when RMIServiceProxy is created
- most of ServiceDiscovery logics is extracted into BaseServiceDiscovery which is abstract class
  exposing only two method (recvServiceInfo, close)
- add field which indicates client how to make connection to server (proxyFactoryHint)
	- for case of inet, it will contain ipv4 address of server
	- the field is not taken into account when evaluate hash because of service discovery
- remove RMIServiceInfo field from Request which was redundant (Not used)
- remove redundant method (unique) from ClientSocketAdapter
- add no-arg constructor in handshakeexception
- add a few methods RMISocket
	- open() : establish connection to server
	- isClosed() : check whether socket connection is closed or not
	- getRemoteName() : return unique string name of remote machine
- change return type of listen method in ServiceAdapter
	- after server start to listen client connection, hint string should be returned to be used at client side proxy
- change API in ServiceProxyFactory
	- remove argument from build method
	- instead of argument in build method, add setTargetService method
- InetRMISocket has two constructor, one is intended to be used as socket wrapper in server side client socket
  and the other is to be used for client side socket to the server. second one should defer connection to the time the open method is invoked instead of connecting immediately
- InetServiceAdapter use default host value with visible address or hostname from separate machine instead of using localhost
- InetServiceAdapter return its ipv4 address recognizable from another machine in private network
- API Changes are reflected on InetServiceProxy
- API Changes are reflected on InetServiceProxyFactory
- Boolean typed block argument is added in startAdvertiser indicates whether the method call will block or not