### PR TITLE
closes #14 by listed below

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.doodream</groupId>
     <artifactId>yarmi-core</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
     <properties>
         <github.global.server>github</github.global.server>

--- a/src/main/java/com/doodream/rmovjs/client/RMIClient.java
+++ b/src/main/java/com/doodream/rmovjs/client/RMIClient.java
@@ -41,7 +41,7 @@ public class RMIClient implements InvocationHandler  {
 
 
 
-    public static <T> T create(RMIServiceProxy serviceProxy, Class svc, Class<T> ctrl) throws IllegalAccessException, InstantiationException {
+    public static <T> T create(RMIServiceProxy serviceProxy, Class svc, Class<T> ctrl) {
         Service service = (Service) svc.getAnnotation(Service.class);
 
         try {
@@ -114,9 +114,8 @@ public class RMIClient implements InvocationHandler  {
         if(endpoint == null) {
             return null;
         }
-        endpoint.applyParam(args);
         try {
-            return serviceProxy.request(endpoint);
+            return serviceProxy.request(endpoint, args);
         } catch (IOException e) {
             serviceProxy.close();
             return Response.error(-1, e.getLocalizedMessage());

--- a/src/main/java/com/doodream/rmovjs/example/client/TestClient.java
+++ b/src/main/java/com/doodream/rmovjs/example/client/TestClient.java
@@ -35,22 +35,18 @@ public class TestClient {
                 if(proxies.size() > 0) {
                     RMIServiceProxy proxy = proxies.get(0);
                     Preconditions.checkNotNull(proxy);
-                    try {
-                        UserIDPController controller = RMIClient.create(proxy, TestService.class, UserIDPController.class);
-                        Preconditions.checkNotNull(controller);
+                    UserIDPController controller = RMIClient.create(proxy, TestService.class, UserIDPController.class);
+                    Preconditions.checkNotNull(controller);
 
-                        User user = new User();
-                        user.setName("David");
+                    User user = new User();
+                    user.setName("David");
 
-                        Response<User> response = controller.createUser(user);
+                    Response<User> response = controller.createUser(user);
 
-                        Preconditions.checkNotNull(response);
-                        Preconditions.checkArgument(response.isSuccessful());
-                        User created = response.getBody();
-                        Preconditions.checkNotNull(created);
-                    } catch (InstantiationException | IllegalAccessException e) {
-
-                    }
+                    Preconditions.checkNotNull(response);
+                    Preconditions.checkArgument(response.isSuccessful());
+                    User created = response.getBody();
+                    Preconditions.checkNotNull(created);
                 }
             }
         });

--- a/src/main/java/com/doodream/rmovjs/model/Request.java
+++ b/src/main/java/com/doodream/rmovjs/model/Request.java
@@ -1,7 +1,6 @@
 package com.doodream.rmovjs.model;
 
 
-import com.doodream.rmovjs.method.RMIMethod;
 import com.doodream.rmovjs.net.ClientSocketAdapter;
 import com.doodream.rmovjs.parameter.Param;
 import com.google.gson.annotations.SerializedName;
@@ -10,7 +9,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.io.IOException;
 import java.util.List;
 
 @Builder
@@ -20,35 +18,18 @@ import java.util.List;
 public class Request {
 
     private transient ClientSocketAdapter client;
+
     @SerializedName("endpoint")
-    private Endpoint endpoint;
+    private String endpoint;
 
+    @SerializedName("params")
+    private List<Param> params;
 
-
-    public void response(Response s) throws IOException {
-        if(client == null) {
-            throw new IOException("No Client");
-        }
-        client.write(s);
-    }
-
-    public final RMIMethod getMethodType() {
-        return endpoint.method;
-    }
-
-    public final String getPath() {
-        return endpoint.path;
-    }
-
-    public final List<Param> getParameters() {
-        return endpoint.params;
-    }
+    // TODO : blob header & blob
 
     public static boolean isValid(Request request) {
         return (request.getEndpoint() != null) &&
-                (request.getPath() != null) &&
-                (request.getParameters() != null) &&
-                (request.getMethodType() != null);
+                (request.getParams() != null);
     }
 
 }

--- a/src/main/java/com/doodream/rmovjs/model/Response.java
+++ b/src/main/java/com/doodream/rmovjs/model/Response.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class Response<T> {
     public static final int SUCCESS = 200;
 
-    Endpoint endpoint;
+    String endpoint;
     T body;
     boolean isSuccessful;
     ResponseBody errorBody;

--- a/src/main/java/com/doodream/rmovjs/net/RMIServiceProxy.java
+++ b/src/main/java/com/doodream/rmovjs/net/RMIServiceProxy.java
@@ -3,49 +3,48 @@ package com.doodream.rmovjs.net;
 import com.doodream.rmovjs.example.template.UserIDPController;
 import com.doodream.rmovjs.model.Endpoint;
 import com.doodream.rmovjs.model.RMIError;
-import com.doodream.rmovjs.model.Request;
 import com.doodream.rmovjs.model.Response;
 
 import java.io.IOException;
 
 public interface RMIServiceProxy {
-    RMIServiceProxy NULL_PROXY = new RMIServiceProxy() {
-        @Override
-        public void open() {
+        RMIServiceProxy NULL_PROXY = new RMIServiceProxy() {
+            @Override
+            public void open() {
 
-        }
+            }
 
-        @Override
-        public boolean isOpen() {
-            return false;
-        }
+            @Override
+            public boolean isOpen() {
+                return false;
+            }
 
-        @Override
-        public Response request(Endpoint endpoint) {
-            return Response.from(RMIError.NOT_FOUND);
-        }
+            @Override
+            public Response request(Endpoint endpoint, Object ...args) {
+                return Response.from(RMIError.NOT_FOUND);
+            }
 
-        @Override
-        public void close() {
+            @Override
+            public void close() {
 
-        }
+            }
 
-        @Override
-        public boolean provide(Class<UserIDPController> userIDPControllerClass) {
-            return false;
-        }
-    };
+            @Override
+            public boolean provide(Class controller) {
+                return false;
+            }
+        };
 
-    /**
-     * build connection to ServiceAdapter of server
-     * can be called
-     * @throws IOException
-     * @throws IllegalAccessException
-     * @throws InstantiationException
-     */
-    void open() throws IOException, IllegalAccessException, InstantiationException;
-    boolean isOpen();
-    Response request(Endpoint endpoint) throws IOException;
-    void close() throws IOException;
-    boolean provide(Class<UserIDPController> userIDPControllerClass);
+        /**
+         * build connection to ServiceAdapter of server
+         * can be called
+         * @throws IOException
+         * @throws IllegalAccessException
+         * @throws InstantiationException
+         */
+        void open() throws IOException, IllegalAccessException, InstantiationException;
+        boolean isOpen();
+        Response request(Endpoint endpoint, Object ...args) throws IOException;
+        void close() throws IOException;
+        boolean provide(Class contoller);
 }

--- a/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java
+++ b/src/main/java/com/doodream/rmovjs/net/ServiceProxyFactory.java
@@ -22,7 +22,7 @@ public interface ServiceProxyFactory {
      * @return
      * @throws IOException
      */
-    RMIServiceProxy build() throws IOException;
+    RMIServiceProxy build();
 
     /**
      *

--- a/src/main/java/com/doodream/rmovjs/net/tcp/TcpServiceProxyFactory.java
+++ b/src/main/java/com/doodream/rmovjs/net/tcp/TcpServiceProxyFactory.java
@@ -1,6 +1,7 @@
 package com.doodream.rmovjs.net.tcp;
 
 import com.doodream.rmovjs.model.RMIServiceInfo;
+import com.doodream.rmovjs.net.BaseServiceProxy;
 import com.doodream.rmovjs.net.RMIServiceProxy;
 import com.doodream.rmovjs.net.ServiceProxyFactory;
 
@@ -25,11 +26,11 @@ public class TcpServiceProxyFactory implements ServiceProxyFactory {
     }
 
     @Override
-    public RMIServiceProxy build() throws IOException {
+    public RMIServiceProxy build() {
         if(host == null) {
             host = serviceInfo.getProxyFactoryHint();
         }
-        return TcpServiceProxy.create(serviceInfo, new TcpRMISocket(host, port));
+        return BaseServiceProxy.create(serviceInfo, new TcpRMISocket(host, port));
     }
 
     @Override

--- a/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceAdvertiser.java
@@ -52,7 +52,6 @@ public class SimpleServiceAdvertiser implements ServiceAdvertiser {
 
     private DatagramPacket buildBroadcastPackaet(RMIServiceInfo info, Converter converter) throws UnsupportedEncodingException {
         byte[] infoByteString = converter.convert(info);
-        Log.debug("broadcasting : {}", new String(infoByteString));
         return new DatagramPacket(infoByteString, infoByteString.length, new InetSocketAddress(BROADCAST_PORT));
     }
 

--- a/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class SimpleServiceDiscovery extends BaseServiceDiscovery {
 
-    private static Logger Log = LogManager.getLogger(SimpleServiceDiscovery.class);
     private DatagramSocket serviceBroadcastSocket;
 
     public SimpleServiceDiscovery() throws SocketException {
@@ -31,14 +30,11 @@ public class SimpleServiceDiscovery extends BaseServiceDiscovery {
 
     @Override
     protected RMIServiceInfo recvServiceInfo(Converter converter) throws IOException {
-        Log.debug(converter);
         byte[] buffer = new byte[64 * 1024];
         Arrays.fill(buffer, (byte) 0);
         DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
         serviceBroadcastSocket.receive(packet);
-        RMIServiceInfo info = converter.invert(packet.getData(), RMIServiceInfo.class);
-        Log.debug(info);
-        return info;
+        return converter.invert(packet.getData(), RMIServiceInfo.class);
     }
 
     @Override

--- a/src/main/java/com/doodream/rmovjs/server/RMIService.java
+++ b/src/main/java/com/doodream/rmovjs/server/RMIService.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 
 /**
  * Created by innocentevil on 18. 5. 4.
@@ -92,8 +91,7 @@ public class RMIService {
     }
 
     private static void buildControllerMap(HashMap<String, RMIController> map, RMIController controller) {
-        List<String> paths = controller.getPaths();
-        Observable.fromIterable(paths)
+        Observable.fromIterable(controller.getEndpoints())
                 .doOnNext(s -> map.put(s, controller))
                 .subscribe();
     }
@@ -109,10 +107,9 @@ public class RMIService {
             return end(Response.from(RMIError.BAD_REQUEST), request);
         }
 
-        final String path = request.getPath();
         Response response;
-        Preconditions.checkNotNull(path);
-        RMIController controller = controllerMap.get(path);
+        Preconditions.checkNotNull(request.getEndpoint());
+        RMIController controller = controllerMap.get(request.getEndpoint());
 
         if(controller != null) {
             response = controller.handleRequest(request);
@@ -131,7 +128,7 @@ public class RMIService {
         try {
             Response.validate(res);
         } catch (RuntimeException e) {
-            InvalidResponseException exception = new InvalidResponseException(String.format("Invalid response for endpoint : %s", req.getEndpoint().getUnique()));
+            InvalidResponseException exception = new InvalidResponseException(String.format("Invalid response for endpoint : %s", req.getEndpoint()));
             exception.initCause(e);
             throw exception;
         }


### PR DESCRIPTION
- replace endpoint which was whole endpoint object with hashcode of endpoint
- parameters moved to the request
- other minor change
	- TcpServiceProxy is not dependent on TCP anymore, so TcpServiceProxy is renamed to BaseServiceProxy (it's not abstract class at the moment)
- clean up unused exception thorws
- clean up log too verbose
closes #14