### PR TITLE
bug fix for Android support

### DIFF
--- a/src/main/java/com/doodream/rmovjs/client/RMIClient.java
+++ b/src/main/java/com/doodream/rmovjs/client/RMIClient.java
@@ -223,7 +223,7 @@ public class RMIClient implements InvocationHandler, Comparable<RMIClient>  {
 
             return rmiClient;
         } catch (Exception e) {
-            Log.error(e.getLocalizedMessage());
+            Log.error("", e);
             return null;
         }
     }

--- a/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java
+++ b/src/main/java/com/doodream/rmovjs/model/RMIServiceInfo.java
@@ -9,20 +9,18 @@ import com.doodream.rmovjs.server.RMIController;
 import com.google.gson.annotations.SerializedName;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(exclude = {"proxyFactoryHint"})
 @Data
 public class RMIServiceInfo {
@@ -49,7 +47,7 @@ public class RMIServiceInfo {
     private List<ControllerInfo> controllerInfos;
 
     /**
-     *  remoteHint is used to guess conntion information (like address or bluetooth device name etc.,)
+     *  remoteHint is used to guess connection information (like address or bluetooth device name etc.,)
      *
      */
     @SerializedName("hint")

--- a/src/main/java/com/doodream/rmovjs/net/tcp/TcpRMISocket.java
+++ b/src/main/java/com/doodream/rmovjs/net/tcp/TcpRMISocket.java
@@ -20,7 +20,8 @@ public class TcpRMISocket implements RMISocket {
     }
 
     public TcpRMISocket(String host, int port) {
-        remoteAddress = InetSocketAddress.createUnresolved(host, port);
+
+        remoteAddress = new InetSocketAddress(host, port);
         socket = null;
     }
 

--- a/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/BaseServiceDiscovery.java
@@ -65,7 +65,7 @@ public abstract class BaseServiceDiscovery implements ServiceDiscovery {
     private static final long TIMEOUT_IN_SEC = 5L;
     private final HashMap<Class, Disposable> disposableMap;
 
-    BaseServiceDiscovery() {
+    public BaseServiceDiscovery() {
         disposableMap = new HashMap<>();
     }
 

--- a/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java
+++ b/src/main/java/com/doodream/rmovjs/sdp/SimpleServiceDiscovery.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.*;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.MulticastChannel;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
when advertised service info is deserialized, instantiation error caused due to absence of default constructor of RMISerivceInfo.
on JVM runtime, default constructor implicitly detected when there is no explicitly declared one, meanwhile, Android Runtime, default constructor should be
explicitly declared. so explicit declaration of default constructor added to POJO class

This change